### PR TITLE
hotfix: correcciones en calendario, pedido v2 y store programaV2

### DIFF
--- a/app/actions/getBloquedDates.ts
+++ b/app/actions/getBloquedDates.ts
@@ -14,9 +14,6 @@ export default async function getBloquedDays() {
     const localDate = subHours(hoyUTC, 6);
     const sd: ServerDate = await getServerDate();
 
-    console.log(hoyUTC);
-    console.log(sd);
-
     const data = await prisma.fechasBloqueadas.findMany({
       where: {
         AND: [

--- a/app/api/pedido/v2/route.ts
+++ b/app/api/pedido/v2/route.ts
@@ -56,14 +56,6 @@ export async function POST(request: Request) {
     const fechaEntregaUtc = naiveStrToUTCDate(p.programa.fechaEntString); // "YYYY-MM-DD HH:mm:ss"
     const fechaRecoUtc = naiveStrToUTCDate(p.programa.fechaRecString);
 
-    console.log("------------");
-    console.log(p?.programa?.fechaRecString);
-    console.log(p?.programa?.fechaEntString);
-    console.log("------------");
-    console.log(currentUser.email);
-    console.log(fechaEntregaUtc);
-    console.log(fechaRecoUtc);
-
     // Prepara el payload de Pedido para reusarlo (bajo recolección existente o nueva)
     const pedidoCrearData = {
       clienteId: currentUser.id,
@@ -241,8 +233,14 @@ export async function POST(request: Request) {
       }
 
       await userActivityRegister(currentUser.id, 15);
-      console.log(pedidoId);
-      console.log("||||||||||||||||||||||||||");
+
+      console.log(
+        `${pedidoId} | ${currentUser.email} -- ${
+          p?.programa?.fechaRecString
+        }/${fechaRecoUtc.toISOString()} ->  ${
+          p?.programa?.fechaEntString
+        }/${fechaEntregaUtc.toISOString()}`
+      );
 
       return {
         recoleccionId, // reusada o creada

--- a/app/portal/crear/steps/components/programaV2/CalendarioEntrega.tsx
+++ b/app/portal/crear/steps/components/programaV2/CalendarioEntrega.tsx
@@ -84,11 +84,10 @@ const CalendarioEntrega: React.FC<CalendarioEntregaProps> = ({ data }) => {
                   onSelect={(d) => pv2.updateEntSelectedDate(d)}
                   className="rounded-md border shadow-sm w-full bg-transparent"
                   classNames={{
-                    selected: `text-white`,
+                    day_selected: `text-white`,
                     day: `h-[42px] w-[42px]`,
-                    weekday: `text-muted-foreground flex-1 select-none rounded-md text-[1rem] font-normal mr-2`,
+                    head_cell: `text-muted-foreground flex-1 select-none rounded-md text-[1rem] font-normal`,
                   }}
-                  captionLayout="label"
                   locale={es}
                   onDayClick={async () => {
                     await sleep(100);

--- a/app/portal/crear/steps/components/programaV2/CalendarioRecoleccion.tsx
+++ b/app/portal/crear/steps/components/programaV2/CalendarioRecoleccion.tsx
@@ -103,11 +103,10 @@ const CalendarioRecoleccion: React.FC<CalendarioRecoleccionProps> = ({
                   }}
                   className="rounded-md border shadow-sm w-full bg-transparent"
                   classNames={{
-                    selected: `text-white`,
+                    day_selected: `bg-neutral-900 text-white`,
                     day: `h-[42px] w-[42px]`,
-                    weekday: `text-muted-foreground flex-1 select-none rounded-md text-[1rem] font-normal mr-2`,
+                    head_cell: `text-muted-foreground flex-1 select-none rounded-md text-[1rem] font-normal`,
                   }}
-                  captionLayout="label"
                   locale={es}
                   onDayClick={async () => {
                     await sleep(100);

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -44,7 +44,7 @@ export function Calendar({
           "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
         ),
         day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+          "bg-rose-500 text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
         day_today: "bg-accent text-accent-foreground",
         day_outside: "text-muted-foreground opacity-50",
         day_disabled: "text-muted-foreground opacity-50",

--- a/version.js
+++ b/version.js
@@ -1,4 +1,4 @@
-export const appVersion = "2.3.1";
+export const appVersion = "2.3.2";
 
 /* 
 2.1.20
@@ -23,5 +23,10 @@ Actualización portal crear envio.
     -paso Pago 
     -Preupload comprobante 
     -Timer programacion
+
+2.3.2 
+29/09/2025 12:47pm
+Cambio en calculo de fechas en programaV2Slice, se elimino getLocaleDate
+
 
  */


### PR DESCRIPTION
Hotfix fechas recoleccion y entrega

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes local date handling in programaV2, updates calendar classNames/styles, trims pedido v2 logs with a concise summary line, and bumps app version to 2.3.2.
> 
> - **Programa (store `programaV2Slice`)**:
>   - Use local-part helpers (`toYMD_LOCAL`, `toYMD10_LOCAL`) for building `YYYY-MM-DD` strings and datetimes.
>   - Type `recBlockedDates`/`entBlockedDates` as `Date[]` and simplify API param usage.
>   - Add validation to prevent `entrega` < `recolección` when not same-day.
>   - Cleanup unused imports and minor state handling.
> - **Calendars (`CalendarioRecoleccion.tsx`, `CalendarioEntrega.tsx`, `components/ui/calendar.tsx`)**:
>   - Switch to `day_selected` and `head_cell` classNames; remove `captionLayout`.
>   - Adjust selected-day styles (global `day_selected` now `bg-rose-500`; recolección adds `bg-neutral-900`).
> - **API `app/api/pedido/v2/route.ts`**:
>   - Remove verbose console logs; add a single concise log summarizing pedido/user and dates.
> - **Misc**:
>   - Bump `appVersion` to `2.3.2` with changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f9b6e3ac51018e9fa1e8aa29cf98cd25f1805c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->