### PR TITLE
Fix/ajustes comprobantes

### DIFF
--- a/app/api/programa/date/today/route.ts
+++ b/app/api/programa/date/today/route.ts
@@ -6,11 +6,20 @@ import { ServerDate } from "@/app/types";
 import { getServerDate } from "@/app/api/utils/validatorUtils";
 import { parseYMDLocal } from "@/app/utils/dateUtils";
 
+// Opción 1: Forzar que este endpoint sea dinámico (sin cache en build)
+export const dynamic = "force-dynamic";
+
 export async function GET(req: Request) {
   try {
     const sd: ServerDate = await getServerDate();
 
-    return new Response(JSON.stringify(sd), { status: 200 });
+    // Opción 2: Headers para evitar cache en cliente/CDN
+    return new Response(JSON.stringify(sd), {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+      },
+    });
   } catch (error: any) {
     return new Response(
       JSON.stringify(JSON.stringify({ error: error.message })),

--- a/app/portal/crear/components/CrearNextButton.tsx
+++ b/app/portal/crear/components/CrearNextButton.tsx
@@ -19,10 +19,10 @@ const CrearNextButton: React.FC<CrearNextButtonProps> = ({
       //className={`w-full mx-4 p-2 rounded-md bg-gradient-to-r from-orange-400 via-rose-500 to-orange-900`}
       className={`w-full p-3 rounded-sm  shadow-lg  ${
         disabled
-          ? "bg-gray-400 bg-gradient-to-r from-gray-300 via-gray-300 to-gray-300 shadow-none"
+          ? "bg-gray-400 bg-gradient-to-r from-gray-300 via-gray-300 to-gray-300 shadow-none cursor-not-allowed"
           : "bg-gradient-to-r from-pink-600 via-rose-500 to-orange-900"
       }`}
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
     >
       <div className="flex flex-row gap-2 items-center justify-center">
         <div


### PR DESCRIPTION
Cambiar a 10:00am el limite recoleccion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cambia lógica de negocio basada en hora (bloqueo de fechas REC) y comportamiento de caching en un endpoint de fecha, lo que puede afectar disponibilidad/selección de fechas si hay clientes que dependían del cutoff previo o de respuestas cacheadas.
> 
> **Overview**
> Ajusta la regla horaria de recolección (REC) cambiando el límite para bloquear el mismo día de **09:30** a **10:00**, manteniendo el resto de reglas (incluida la de municipio 10).
> 
> Evita que `app/api/programa/date/today` se sirva con cache al forzar modo dinámico y añadir `Cache-Control: no-store` en la respuesta.
> 
> Endurece el botón `CrearNextButton` para que cuando esté `disabled` no ejecute `onClick` y muestre cursor `not-allowed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c3cc4e7f6dfb318dbc7542b96901d09c0bb9ea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->