### PR TITLE
Fix/ajustes comprobantes

### DIFF
--- a/app/actions/apiQuerys.ts
+++ b/app/actions/apiQuerys.ts
@@ -873,3 +873,26 @@ export async function getAvisoActivo() {
 
   return response.data;
 }
+
+export async function getColoniasSinCobertura(municipioId: number) {
+  const result = await axios
+    .post(`/api/colonias/sin_cobertura/${municipioId}`)
+    .then((res) => {
+      const response: ApiResponse = {
+        status: 1,
+        statusMessage: "OK",
+        response: { data: res.data },
+      };
+      return response;
+    })
+    .catch((error) => {
+      const response: ApiResponse = {
+        status: 2,
+        statusMessage: "Error de API",
+        response: { data: {}, error: error },
+      };
+      return response;
+    });
+
+  return result;
+}

--- a/app/api/colonias/[cpId]/route.ts
+++ b/app/api/colonias/[cpId]/route.ts
@@ -44,6 +44,7 @@ export async function POST(request: Request, { params }: { params: IParams }) {
     cpId: col.cpId,
     municipioId: col.municipio_id,
     tipo: col.tipo,
+    custom: col.custom,
   }));
 
   formattedColonias?.push({

--- a/app/api/colonias/sin_cobertura/[municipioId]/route.ts
+++ b/app/api/colonias/sin_cobertura/[municipioId]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import prisma from "@/app/libs/prismadb";
+
+interface IParams {
+  municipioId?: string;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: IParams }
+) {
+  const { municipioId } = params;
+
+  if (!municipioId || typeof municipioId !== "string") {
+    throw new Error("Invalid ID");
+  }
+
+  const colonias = await prisma.catalogoColonias.findMany({
+    where: {
+      custom: true,
+      cp: {
+        municipioId: parseInt(municipioId),
+      },
+    },
+    orderBy: {
+      colonia: "asc",
+    },
+  });
+
+  if (!colonias || colonias.length === 0) {
+    return NextResponse.json({
+      status: 1,
+      statusMessage: "OK",
+      colonias: [],
+    });
+  }
+
+  const formattedColonias = colonias.map((col) => ({
+    value: col.id,
+    label: col.colonia,
+    cpId: col.cpId,
+  }));
+
+  return NextResponse.json({
+    status: 1,
+    statusMessage: "OK",
+    colonias: formattedColonias,
+  });
+}

--- a/app/api/programa/date/today/route.ts
+++ b/app/api/programa/date/today/route.ts
@@ -6,11 +6,20 @@ import { ServerDate } from "@/app/types";
 import { getServerDate } from "@/app/api/utils/validatorUtils";
 import { parseYMDLocal } from "@/app/utils/dateUtils";
 
+// Opción 1: Forzar que este endpoint sea dinámico (sin cache en build)
+export const dynamic = "force-dynamic";
+
 export async function GET(req: Request) {
   try {
     const sd: ServerDate = await getServerDate();
 
-    return new Response(JSON.stringify(sd), { status: 200 });
+    // Opción 2: Headers para evitar cache en cliente/CDN
+    return new Response(JSON.stringify(sd), {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+      },
+    });
   } catch (error: any) {
     return new Response(
       JSON.stringify(JSON.stringify({ error: error.message })),

--- a/app/portal/crear/components/CrearNextButton.tsx
+++ b/app/portal/crear/components/CrearNextButton.tsx
@@ -19,10 +19,10 @@ const CrearNextButton: React.FC<CrearNextButtonProps> = ({
       //className={`w-full mx-4 p-2 rounded-md bg-gradient-to-r from-orange-400 via-rose-500 to-orange-900`}
       className={`w-full p-3 rounded-sm  shadow-lg  ${
         disabled
-          ? "bg-gray-400 bg-gradient-to-r from-gray-300 via-gray-300 to-gray-300 shadow-none"
+          ? "bg-gray-400 bg-gradient-to-r from-gray-300 via-gray-300 to-gray-300 shadow-none cursor-not-allowed"
           : "bg-gradient-to-r from-pink-600 via-rose-500 to-orange-900"
       }`}
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
     >
       <div className="flex flex-row gap-2 items-center justify-center">
         <div


### PR DESCRIPTION
Colonias y cp sin cobertura

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cambia validaciones de captura de dirección y reglas de calendario de recolección, lo que puede bloquear flujos existentes si los datos de `coberturaId`/`custom` están incompletos o mal marcados. También ajusta comportamiento de cache y un límite horario, con impacto directo en disponibilidad de fechas.
> 
> **Overview**
> Mejora el manejo de *códigos postales y colonias sin cobertura* durante la captura de destinos: el API de colonias por CP ahora expone el flag `custom`, el selector marca/inhabilita esas opciones, y al escribir “OTRA COLONIA” se valida por similitud para bloquear nombres que coincidan con colonias sin cobertura; además, si `codigo.coberturaId === 100` se rechaza el CP con mensaje de error.
> 
> Agrega el endpoint `POST /api/colonias/sin_cobertura/[municipioId]` y una acción `getColoniasSinCobertura()` para el flujo *sin CP*, cargando la lista por municipio y bloqueando el avance si la colonia capturada coincide.
> 
> Ajusta backend de programación: `GET /api/programa/date/today` se fuerza como dinámico y sin cache, y `POST /api/programa/v2/rec` mueve el corte horario de bloqueo del mismo día a las 10:00. `CrearNextButton` ahora no dispara `onClick` cuando está deshabilitado y muestra cursor bloqueado.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c66477027973e0ea852440545abf6ba85209f59f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->